### PR TITLE
dub: Switch default target type from `sourceLibrary` to `library`

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -6,6 +6,15 @@
 	"copyright": "Copyright (c) 2015 Manu Evans",
 	"license": "Boost",
 	"importPaths": ["."],
-	"targetType": "sourceLibrary",
-	"sourcePaths": ["."]
+	"targetType": "library",
+	"sourcePaths": ["."],
+	"configurations": [
+		{
+			"name": "default"
+		},
+		{
+			"name": "sourceLibrary",
+			"targetType": "sourceLibrary"
+		}
+	]
 }


### PR DESCRIPTION
Closes https://github.com/TurkeyMan/color/issues/16.

To overcome issues with reggae when multiple dependencies depend on `color`, which can result in reggae generating multiple conflicting ninja build targets.

And add a new `sourceLibrary` config.